### PR TITLE
make tabbar respond to regular scroll

### DIFF
--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -2573,7 +2573,7 @@ ui_signal_from_box(UI_Box *box)
             }
             if(!(box->flags & UI_BoxFlag_ViewScrollY))
             {
-              if(box->flags & UI_BoxFlag_ViewScrollX)
+              if(delta.x == 0 && box->flags & UI_BoxFlag_ViewScrollX)
               {
                 delta.x = delta.y;
               }

--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -2573,6 +2573,10 @@ ui_signal_from_box(UI_Box *box)
             }
             if(!(box->flags & UI_BoxFlag_ViewScrollY))
             {
+              if(box->flags & UI_BoxFlag_ViewScrollX)
+              {
+                delta.x = delta.y;
+              }
               delta.y = 0;
             }
             os_eat_event(events, event);


### PR DESCRIPTION
global change such that a regular scroll in a scrolling region where there is no vertical scroll will scroll horizontally instead

that way tab bars are much friendlier to use