### PR TITLE
fix utf8_decode failing on 16-bit codepoints at end of string

### DIFF
--- a/src/base/base_strings.c
+++ b/src/base/base_strings.c
@@ -1228,7 +1228,7 @@ utf8_decode(U8 *str, U64 max){
     }break;
     case 2:
     {
-      if (2 < max)
+      if (1 < max)
       {
         U8 cont_byte = str[1];
         if (utf8_class[cont_byte >> 3] == 0)


### PR DESCRIPTION
`utf8_decode`'s 16-bit case checks for `max >= 3` rather than `max >= 2`, which means the sequence will fail to decode if `max = 2` (E.g. when the sequence is the last in a string).

Example:
```c
// 'å' & 'ñ' are each encoded in utf8 using a 16-bit sequence.
// str16_from_8 calls utf8_decode internally.
Temp scratch = scratch_begin(0, 0);
String16 result = str16_from_8(scratch.arena, str8_lit("å ñ"));
```

Expected result:
```c
{
  .str = {0x00e5, 0x0020, 0x00f1}, // "å ñ"
  .size = 3
}
```

Actual result:
```c
{
  .str = {0x00e5, 0x0020, 0x003f, 0x003f}, // "å ??"
  .size = 4
}
```