### PR TITLE
Icon Centering

### DIFF
--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -2278,7 +2278,7 @@ ui_box_text_position(UI_Box *box)
   F_Tag font = box->font;
   F32 font_size = box->font_size;
   F_Metrics font_metrics = f_metrics_from_tag_size(font, font_size);
-  result.y = ceil_f32((box->rect.p0.y + box->rect.p1.y)/2.f + (font_metrics.capital_height/2) - font_metrics.line_gap/2);
+  result.y = ceil_f32((box->rect.p0.y + box->rect.p1.y)/2.f + (font_metrics.capital_height/2) - font_metrics.line_gap/2 - 1);
   switch(box->text_align)
   {
     default:
@@ -2289,7 +2289,7 @@ ui_box_text_position(UI_Box *box)
     case UI_TextAlign_Center:
     {
       Vec2F32 advance = box->display_string_runs.dim;
-      result.x = (box->rect.p0.x + box->rect.p1.x)/2 - advance.x/2;
+      result.x = (box->rect.p0.x + box->rect.p1.x)/2 - advance.x/2 - 1;
       result.x = ClampBot(result.x, box->rect.x0);
     }break;
     case UI_TextAlign_Right:


### PR DESCRIPTION
Hi!

When looking at the ui it seems to me that centered text particularly icons have some offset from center. 

I did a bit of experimentation and at least on my machine with no ui scaling it seems like icons are off center by one. See gif and screenshots. I don't suggest that you merge this as is, this is probably not the correct solution. I just wanted to bring this to your attention.

Have a fantastic day! :)


Here is a before and after gif and the raw images that the gif is based on:

![befor-after](https://github.com/EpicGamesExt/raddebugger/assets/840235/8b7180c3-ca3e-4be1-8367-5b4713d19294)

Before:
![before](https://github.com/EpicGamesExt/raddebugger/assets/840235/e000ae39-6424-41d3-98f8-0cec7e73c667)

After:
![after](https://github.com/EpicGamesExt/raddebugger/assets/840235/a9c1ed5a-1af6-4705-bfbd-8d778ca3abb3)

