### PR TITLE
Fix str8_from_u64

### DIFF
--- a/src/base/base_strings.c
+++ b/src/base/base_strings.c
@@ -621,7 +621,7 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 0; idx < result.size; idx += 1)
+      for(U64 idx = 1; idx < result.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {

--- a/src/metagen/metagen_base/metagen_base_string.c
+++ b/src/metagen/metagen_base/metagen_base_string.c
@@ -681,7 +681,7 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 0; idx < result.size; idx += 1)
+      for(U64 idx = 1; idx < result.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {


### PR DESCRIPTION
Bug: Has String8.size take into account the terminating null it lacks - 1 index.

`internal String8 str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_separator)`
![image](https://github.com/EpicGamesExt/raddebugger/assets/51819886/9183aae4-e7aa-44a2-8fec-6e0e8ffcff7f)

Not sure you want to fix it that way though
