### PR TITLE
Dev

### DIFF
--- a/src/base/base_strings.c
+++ b/src/base/base_strings.c
@@ -621,28 +621,24 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 1; idx < result.size; idx += 1)
+      for(U64 idx = 0; idx < result.size-prefix.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {
           result.str[result.size - idx - 1] = digit_group_separator;
           digits_until_separator = digit_group_size+1;
         }
-        else
+        else if(u64_reduce != 0)
         {
           result.str[result.size - idx - 1] = char_to_lower(integer_symbols[u64_reduce%radix]);
           u64_reduce /= radix;
         }
-        digits_until_separator -= 1;
-        if(u64_reduce == 0)
+        else
         {
-          break;
+          result.str[result.size - idx - 1] = '0';
         }
-      }
-      for(U64 leading_0_idx = 0; leading_0_idx < needed_leading_0s; leading_0_idx += 1)
-      {
-        result.str[prefix.size + leading_0_idx] = '0';
-      }
+        digits_until_separator -= 1;        
+      }      
     }
     
     // rjf: fill prefix

--- a/src/base/base_strings.c
+++ b/src/base/base_strings.c
@@ -621,7 +621,7 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 0; idx < result.size; idx += 1)
+      for(U64 idx = 1; idx < result.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {

--- a/src/metagen/metagen_base/metagen_base_string.c
+++ b/src/metagen/metagen_base/metagen_base_string.c
@@ -681,28 +681,24 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 1; idx < result.size; idx += 1)
+      for(U64 idx = 0; idx < result.size-prefix.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {
           result.str[result.size - idx - 1] = digit_group_separator;
           digits_until_separator = digit_group_size+1;
         }
-        else
+        else if(u64_reduce != 0)
         {
           result.str[result.size - idx - 1] = char_to_lower(integer_symbols[u64_reduce%radix]);
           u64_reduce /= radix;
         }
-        digits_until_separator -= 1;
-        if(u64_reduce == 0)
+        else
         {
-          break;
+          result.str[result.size - idx - 1] = '0';
         }
-      }
-      for(U64 leading_0_idx = 0; leading_0_idx < needed_leading_0s; leading_0_idx += 1)
-      {
-        result.str[prefix.size + leading_0_idx] = '0';
-      }
+        digits_until_separator -= 1;        
+      }      
     }
     
     // rjf: fill prefix

--- a/src/metagen/metagen_base/metagen_base_string.c
+++ b/src/metagen/metagen_base/metagen_base_string.c
@@ -681,7 +681,7 @@ str8_from_u64(Arena *arena, U64 u64, U32 radix, U8 min_digits, U8 digit_group_se
     {
       U64 u64_reduce = u64;
       U64 digits_until_separator = digit_group_size;
-      for(U64 idx = 0; idx < result.size; idx += 1)
+      for(U64 idx = 1; idx < result.size; idx += 1)
       {
         if(digits_until_separator == 0 && digit_group_separator != 0)
         {


### PR DESCRIPTION
Sorry for the `Dev` title, not used to Github, it seems I can't change it.

**The bug**: the leading zeros can't have the separator. It gives a bug when you do. 
The computation takes the amount of digit (leading_zero+digit_value) for the string but it does not add the separator in leading zeros which means that you lack one or more iteration in the loop of leading zeros

If you don't want the separator on leading_zeros (which seems to be the case by looking at `needed_separators = (needed_digits+needed_leading_0s)/digit_group_size;`) remove the `+needed_leading_0s` part and you're good to go.

On value = `-99`
`str8_from_s64(arena, value, 10, 5, '.');`
![image](https://github.com/EpicGamesExt/raddebugger/assets/51819886/c95a3be4-933b-4adb-944d-30e3d38b7260)


`str8_from_s64(arena, value, 8, 5, '.');`
![image](https://github.com/EpicGamesExt/raddebugger/assets/51819886/9d876a8f-a6c9-469b-80b7-34f3f80c9192)


`str8_from_s64(arena, value, 2, 10, '.');`
![image](https://github.com/EpicGamesExt/raddebugger/assets/51819886/1bd835dd-b82f-4a78-9eea-cf59342a0bee)



