### PR TITLE
Slightly stronger hash function in ui_hash_from_string()

### DIFF
--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -18,7 +18,7 @@ ui_hash_from_string(U64 seed, String8 string)
   U64 result = seed;
   for(U64 i = 0; i < string.size; i += 1)
   {
-    result = ((result << 5) + result) + string.str[i];
+    result = ((result << 8) + result) + string.str[i];
   }
   return result;
 }


### PR DESCRIPTION
The original hash function had a few collisions on the dictionary of English words, e.g. "hot"-"iOS". The hash doesn't change e.g. if a character is incremented and the next character is decreased by 33, e.g. "At"-"BS". There's maybe a not-completely-negligible chance that something like this would accidentally happen in practice, so here's a simple tweak to avoid it - just change 33 to 257.