### PR TITLE
Remove size parameter from os_release

### DIFF
--- a/src/base/base_arena.c
+++ b/src/base/base_arena.c
@@ -27,7 +27,7 @@ arena_alloc__sized(U64 init_res, U64 init_cmt)
     if(!os_commit_large(memory, cmt))
     {
       memory = 0;
-      os_release(memory, res);
+      os_release(memory);
     }
   }
   else
@@ -39,7 +39,7 @@ arena_alloc__sized(U64 init_res, U64 init_cmt)
     if(!os_commit(memory, cmt))
     {
       memory = 0;
-      os_release(memory, res);
+      os_release(memory);
     }
   }
   
@@ -88,7 +88,7 @@ arena_release(Arena *arena)
 {
   for (Arena *node = arena->current, *prev = 0; node != 0; node = prev) {
     prev = node->prev;
-    os_release(node, node->res);
+    os_release(node);
   }
 }
 
@@ -187,7 +187,7 @@ arena_pop_to(Arena *arena, U64 big_pos_unclamped)
   Arena *current = arena->current;
   for (Arena *prev = 0; current->base_pos >= big_pos; current = prev) {
     prev = current->prev;
-    os_release(current, current->res);
+    os_release(current);
   }
   AssertAlways(current);
   arena->current = current;

--- a/src/os/core/linux/os_core_linux.c
+++ b/src/os/core/linux/os_core_linux.c
@@ -851,7 +851,9 @@ os_init(void)
 
 internal void*
 os_reserve(U64 size){
-  void *result = mmap(0, size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  usize *result = map(0, size + sizeof(usize), PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  *result = size;
+  result++
   return(result);
 }
 
@@ -881,8 +883,9 @@ os_decommit(void *ptr, U64 size){
 }
 
 internal void
-os_release(void *ptr, U64 size){
-  munmap(ptr, size);
+os_release(void *ptr){
+  usize *memory = ptr;
+  munmap(--memory, *--memory);
 }
 
 internal void

--- a/src/os/core/os_core.h
+++ b/src/os/core/os_core.h
@@ -211,7 +211,7 @@ internal B32   os_commit(void *ptr, U64 size);
 internal void* os_reserve_large(U64 size);
 internal B32   os_commit_large(void *ptr, U64 size);
 internal void  os_decommit(void *ptr, U64 size);
-internal void  os_release(void *ptr, U64 size);
+internal void  os_release(void *ptr);
 
 internal B32 os_set_large_pages(B32 flag);
 internal B32 os_large_pages_enabled(void);

--- a/src/os/core/win32/os_core_win32.c
+++ b/src/os/core/win32/os_core_win32.c
@@ -278,7 +278,7 @@ os_decommit(void *ptr, U64 size){
 }
 
 internal void
-os_release(void *ptr, U64 size){
+os_release(void *ptr){
   // NOTE(rjf): size not used - not necessary on Windows, but necessary for other OSes.
   VirtualFree(ptr, 0, MEM_RELEASE);
 }


### PR DESCRIPTION
The size of the memory can be placed right before the allocation, thus it makes it tirival to track the size. The size can be grabbed with accessing usize bytes before the allocated chunk.