### PR TITLE
Stop Alt keybinds from making a system beep

### DIFF
--- a/src/os/gfx/win32/os_gfx_win32.c
+++ b/src/os/gfx/win32/os_gfx_win32.c
@@ -520,7 +520,7 @@ w32_wnd_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       
       case WM_SYSCHAR:
       {
-        result = DefWindowProcW(hwnd, uMsg, wParam, lParam);
+        result = 0;
       }break;
       
       case WM_CHAR:


### PR DESCRIPTION
I'm used to my debugging keybinds being on Alt+key, but windows makes a noise on Alt keybinds if the Alt keybind isn't in the menu bar which is very annoying.  This fixes it and the menu bar still works, alt+f4 still works, everything still works, just no more beeping.