### PR TITLE
fixed line number binary search for last range in line number map

### DIFF
--- a/src/lib_rdi_format/rdi_format_parse.c
+++ b/src/lib_rdi_format/rdi_format_parse.c
@@ -393,7 +393,7 @@ rdi_line_voffs_from_num(RDI_ParsedSourceLineMap *map, RDI_U32 linenum, RDI_U32 *
   {
     RDI_U32 first = map->ranges[closest_i];
     RDI_U32 opl   = map->ranges[closest_i + 1];
-    if(opl < map->voff_count)
+    if(opl <= map->voff_count)
     {
       result = map->voffs + first;
       *n_out = opl - first;


### PR DESCRIPTION
Found a buggy if-check in the line number search that discards last range in line maps. This lead to breakpoints not being set on last line in some functions.