### PR TITLE
Fix open flags for rdi_from_dwarf

### DIFF
--- a/src/os/core/linux/os_core_linux.c
+++ b/src/os/core/linux/os_core_linux.c
@@ -250,17 +250,11 @@ os_file_open(OS_AccessFlags flags, String8 path)
   Temp scratch = scratch_begin(0, 0);
   String8 path_copy = push_str8_copy(scratch.arena, path);
   int lnx_flags = 0;
-  if(flags & (OS_AccessFlag_Read|OS_AccessFlag_Write))
+  switch (flags & (OS_AccessFlag_Read|OS_AccessFlag_Write))
   {
-    lnx_flags = O_RDWR;
-  }
-  else if(flags & OS_AccessFlag_Write)
-  {
-    lnx_flags = O_WRONLY;
-  }
-  else if(flags & OS_AccessFlag_Read)
-  {
-    lnx_flags = O_RDONLY;
+    case OS_AccessFlag_Read: lnx_flags = O_RDONLY; break;
+    case OS_AccessFlag_Write: lnx_flags = O_WRONLY; break;
+    case OS_AccessFlag_Read|OS_AccessFlag_Write: lnx_flags = O_RDWR; break;
   }
   if(flags & OS_AccessFlag_Append)
   {

--- a/src/rdi_from_dwarf/rdi_from_dwarf.c
+++ b/src/rdi_from_dwarf/rdi_from_dwarf.c
@@ -436,7 +436,7 @@ entry_point(CmdLine *cmd_line)
   
 #define PARSE_CHECK_ERROR(p,fmt,...) do{ if ((p) == 0){ \
 successful_parse = 0; \
-fprintf(stdout, "error(parsing): " fmt "\n", __VA_ARGS__); \
+fprintf(stdout, "error(parsing): " fmt "\n",##__VA_ARGS__); \
 } }while(0)
   
   // parse elf


### PR DESCRIPTION
Hello all,

When experimenting with ``rdi_from_dwarf`` on Linux, I noticed that it failed to compile initially because clang handles ``__VA_ARGS__`` differently on Linux than it does (for whatever reason...). After that, I tested ``rdi_from_dwarf`` with the following command line and got this as a response

```
$ build/rdi_from_dwarf --elf:build/rdi_from_dwarf --dump
error(input): could not load input file 'build/rdi_from_dwarf'
```

After an ``strace``, I found the problem to be that ``os_file_open`` always used ``O_RDWR``. This patch fixes ``lnx_flags`` to use ``O_RDONLY`` and ``O_WRONLY`` when appropriate.