### PR TITLE
Setup symbol path in win32 exception handler to the .exe folder

### DIFF
--- a/src/os/core/win32/os_core_win32.c
+++ b/src/os/core/win32/os_core_win32.c
@@ -1362,8 +1362,12 @@ win32_exception_filter(EXCEPTION_POINTERS* exception_ptrs)
       HANDLE thread = GetCurrentThread();
       CONTEXT* context = exception_ptrs->ContextRecord;
       
+      WCHAR module_path[MAX_PATH];
+      GetModuleFileNameW(NULL, module_path, ArrayCount(module_path));
+      PathRemoveFileSpecW(module_path);
+      
       dbg_SymSetOptions(SYMOPT_EXACT_SYMBOLS | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
-      if(dbg_SymInitializeW(process, L"", TRUE))
+      if(dbg_SymInitializeW(process, module_path, TRUE))
       {
         // check that raddbg.pdb file is good
         B32 raddbg_pdb_valid = 0;


### PR DESCRIPTION
Otherwise it was trying lookup .pdb files only in the current folder, as that is how .exe's are built (/pdbaltpath). This change now makes exception handler to load .pdb from the same folder as where .exe is.