### PR TITLE
fix typo in 'Step Into' hover card

### DIFF
--- a/src/raddbg/raddbg_core.c
+++ b/src/raddbg/raddbg_core.c
@@ -6057,7 +6057,7 @@ rd_window_frame(RD_Window *ws)
                 UI_Tooltip
                   RD_Font(RD_FontSlot_Main)
                   UI_FontSize(rd_font_size_from_slot(RD_FontSlot_Main))
-                  ui_labelf("Step Over");
+                  ui_labelf("Step Into");
               }
               else
               {


### PR DESCRIPTION
Both stepping in/over were marked as stepping over.