### PR TITLE
Fix compiling on linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ clang_debug="$compiler -g -O0 -DBUILD_DEBUG=1 ${clang_common} ${auto_compile_fla
 clang_release="$compiler -g -O2 -DBUILD_DEBUG=0 ${clang_common} ${auto_compile_flags}"
 clang_link="-lpthread -lm -lrt -ldl"
 clang_out="-o"
-gcc_common="-I../src/ -I../local/ -g -DBUILD_GIT_HASH=\"$git_hash\" -DBUILD_GIT_HASH_FULL=\"$git_hash_full\" -Wno-unknown-warning-option -Wall -Wno-missing-braces -Wno-unused-function -Wno-attributes -Wno-unused-value -Wno-unused-variable -Wno-unused-local-typedef -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-compare-distinct-pointer-types -D_USE_MATH_DEFINES -Dstrdup=_strdup -Dgnu_printf=printf"
+gcc_common="-I../src/ -I/usr/include/freetype2/ -I../local/ -g -DBUILD_GIT_HASH=\"$git_hash\" -DBUILD_GIT_HASH_FULL=\"$git_hash_full\" -Wno-multichar -Wno-comment -Wall -Wno-missing-braces -Wno-unused-function -Wno-attributes -Wno-unused-value -Wno-unused-variable -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-compare-distinct-pointer-types -D_USE_MATH_DEFINES -Dstrdup=_strdup -Dgnu_printf=printf"
 gcc_debug="$compiler -g -O0 -DBUILD_DEBUG=1 ${gcc_common} ${auto_compile_flags}"
 gcc_release="$compiler -g -O2 -DBUILD_DEBUG=0 ${gcc_common} ${auto_compile_flags}"
 gcc_link="-lpthread -lm -lrt -ldl"

--- a/src/base/base_log.c
+++ b/src/base/base_log.c
@@ -4,9 +4,10 @@
 ////////////////////////////////
 //~ rjf: Globals/Thread-Locals
 
-C_LINKAGE thread_static Log *log_active;
 #if !BUILD_SUPPLEMENTARY_UNIT
 C_LINKAGE thread_static Log *log_active = 0;
+#else
+C_LINKAGE thread_static Log *log_active;
 #endif
 
 ////////////////////////////////

--- a/src/base/base_thread_context.c
+++ b/src/base/base_thread_context.c
@@ -4,9 +4,10 @@
 ////////////////////////////////
 //~ rjf: Globals
 
-C_LINKAGE thread_static TCTX *tctx_thread_local;
 #if !BUILD_SUPPLEMENTARY_UNIT
 C_LINKAGE thread_static TCTX *tctx_thread_local = 0;
+#else
+C_LINKAGE thread_static TCTX *tctx_thread_local;
 #endif
 
 ////////////////////////////////

--- a/src/demon/linux/demon_core_linux.h
+++ b/src/demon/linux/demon_core_linux.h
@@ -279,7 +279,7 @@ struct DMN_LNX_State
   Arena *arena;
   
   // rjf: access locking mechanism
-  OS_Handle access_mutex;
+  Mutex access_mutex;
   B32 access_run_state;
   
   // rjf: deferred events

--- a/src/metagen/metagen_base/metagen_base_log.c
+++ b/src/metagen/metagen_base/metagen_base_log.c
@@ -4,9 +4,10 @@
 ////////////////////////////////
 //~ rjf: Globals/Thread-Locals
 
-C_LINKAGE thread_static Log *log_active;
 #if !BUILD_SUPPLEMENTARY_UNIT
 C_LINKAGE thread_static Log *log_active = 0;
+#else
+C_LINKAGE thread_static Log *log_active;
 #endif
 
 ////////////////////////////////

--- a/src/metagen/metagen_base/metagen_base_thread_context.c
+++ b/src/metagen/metagen_base/metagen_base_thread_context.c
@@ -4,9 +4,10 @@
 ////////////////////////////////
 // NOTE(allen): Thread Context Functions
 
-C_LINKAGE thread_static TCTX* tctx_thread_local;
 #if !BUILD_SUPPLEMENTARY_UNIT
 C_LINKAGE thread_static TCTX* tctx_thread_local = 0;
+#else
+C_LINKAGE thread_static TCTX* tctx_thread_local;
 #endif
 
 internal void

--- a/src/os/core/linux/os_core_linux.c
+++ b/src/os/core/linux/os_core_linux.c
@@ -999,8 +999,10 @@ os_cond_var_wait_rw(CondVar cv, RWMutex mutex_rw, B32 write_mode, U64 endt_us)
   endt_timespec.tv_sec = endt_us/Million(1);
   endt_timespec.tv_nsec = Thousand(1) * (endt_us - (endt_us/Million(1))*Million(1));
   B32 result = 0;
-  pthread_mutex_lock(&cv_entity->cv.rwlock_mutex_handle);
+
+  // To avoid deadlock, it is necessary to unlock rwmutex_handle before locking cv.rwlock_mutex_handle
   pthread_rwlock_unlock(&rw_mutex_entity->rwmutex_handle);
+  pthread_mutex_lock(&cv_entity->cv.rwlock_mutex_handle);
   for(;;)
   {
     int wait_result = pthread_cond_timedwait(&cv_entity->cv.cond_handle, &cv_entity->cv.rwlock_mutex_handle, &endt_timespec);


### PR DESCRIPTION
- Update types in `os_core_linux.c`to match `os_core_win32.c`
- Remove redeclarations when `BUILD_SUPPLEMENTARY_UNIT` is zero (which produced a compile error in gcc but not clang)
- Update gcc flags to include freetype and ignore warnings on multi-line comments and multi-character literals.
- Fix deadlock in `os_cond_var_wait_rw` when typing into an editable field by unlocking `rwmutex_handle` before locking `cv.rwlock_mutex_handle`.